### PR TITLE
imports: fix vendored import paths

### DIFF
--- a/imports/imports.go
+++ b/imports/imports.go
@@ -1,6 +1,9 @@
 package imports
 
-import "go/types"
+import (
+	"go/types"
+	"strings"
+)
 
 type Importer interface {
 	AddImportsFrom(t types.Type)
@@ -29,13 +32,26 @@ func (imp *imports) AddImportsFrom(t types.Type) {
 		if pkg.Name() == imp.currentpkg {
 			return
 		}
-		imp.imp[pkg.Path()] = pkg.Name()
+		imp.imp[vendorlessImportPath(pkg.Path())] = pkg.Name()
 	case *types.Tuple:
 		for i := 0; i < el.Len(); i++ {
 			imp.AddImportsFrom(el.At(i).Type())
 		}
 	default:
 	}
+}
+
+// vendorlessImportPath returns the devendorized version of the provided import path.
+// e.g. "foo/bar/vendor/a/b" => "a/b"
+func vendorlessImportPath(ipath string) string {
+	// Devendorize for use in import statement.
+	if i := strings.LastIndex(ipath, "/vendor/"); i >= 0 {
+		return ipath[i+len("/vendor/"):]
+	}
+	if strings.HasPrefix(ipath, "vendor/") {
+		return ipath[len("vendor/"):]
+	}
+	return ipath
 }
 
 // AddImportsFrom adds imports used in the passed type

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -1,0 +1,20 @@
+package imports_test
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/ernesto-jimenez/gogen/imports"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDevendorizeImportPaths checks if vendored
+// import paths are devendorized correctly.
+func TestDevendorizeImportPaths(t *testing.T) {
+	i := imports.New("github.com/ernesto-jimenez/gogen/imports")
+	pkg := types.NewPackage("github.com/ernesto-jimenez/gogen/vendor/github.com/stretchr/testify/mock", "mock")
+	named := types.NewNamed(types.NewTypeName(token.Pos(0), pkg, "", &types.Array{}), &types.Array{}, nil)
+	i.AddImportsFrom(named)
+	require.Equal(t, map[string]string{"github.com/stretchr/testify/mock": "mock"}, i.Imports())
+}


### PR DESCRIPTION
Before, vendored import paths would not be devendorized
for mocks generated using goautomock. This would fail
compilation for the generated code because vendored
import paths are not allowed to be used in Go's
import statements.

Now, the import paths are correctly devendorized by using
vendorlessImportPath() that was shamelessly copied form
https://github.com/golang/tools/blob/5cb1c80a83ef2a98bbc7b2fba1305239bb684fbe/imports/fix.go#L579-L590
